### PR TITLE
Failing test for alt-key combo not working on a Mac

### DIFF
--- a/tests/acceptance/keyboard-combo-test.js
+++ b/tests/acceptance/keyboard-combo-test.js
@@ -95,5 +95,38 @@ module('Acceptance | ember keyboard | keyboard combos', function(hooks) {
           });
       });
     });
+    module('alt', function() {
+      test('alt+KeyB', async function(assert) {
+        assert.expect(3);
+
+        await textChanged(
+          assert,
+          () => keyPress('alt+KeyB'), {
+            selectorName: 'alt-b',
+            beforeValue: 'Alt + B not pressed',
+            afterValue: 'Alt + B pressed'
+          });
+      });
+
+      test('alt+KeyB on a Mac', async function(assert) {
+        assert.expect(3);
+
+        const altBDownProperties = {
+          code: 'KeyB',
+          key: '∫',
+          keyCode: 66,
+          which: 66,
+          altKey: true
+        };
+
+        await textChanged(
+          assert,
+          () => triggerEvent(document.body, 'keypress', altBDownProperties), {
+            selectorName: 'alt-b',
+            beforeValue: 'Alt + B not pressed',
+            afterValue: 'Alt + B pressed'
+          });
+      });
+    });
   });
 });

--- a/tests/dummy/app/controllers/test-scenario/keyboard-combo.js
+++ b/tests/dummy/app/controllers/test-scenario/keyboard-combo.js
@@ -5,6 +5,7 @@ export default Controller.extend({
   wasSPressed: false,
   wasSlashPressed: false,
   wasQuestionMarkPressed: false,
+  wasAltBPressed: false,
   actions: {
     onCtrlK() {
       this.set('wasCtrlKPressed', true);
@@ -17,6 +18,9 @@ export default Controller.extend({
     },
     onQuestionMark() {
       this.set('wasQuestionMarkPressed', true);
+    },
+    onAltB() {
+      this.set('wasAltBPressed', true);
     }
   }
 });

--- a/tests/dummy/app/templates/test-scenario/keyboard-combo.hbs
+++ b/tests/dummy/app/templates/test-scenario/keyboard-combo.hbs
@@ -40,3 +40,12 @@
   key='shift+Slash'
   onPress=(action 'onQuestionMark')
 }}
+
+<span data-test-alt-b>
+  {{if this.wasAltBPressed 'Alt + B pressed' 'Alt + B not pressed'}}
+</span>
+
+{{keyboard-press
+  key='alt+KeyB'
+  onPress=(action 'onAltB')
+}}


### PR DESCRIPTION
The support for software keyboard mapping (here: https://github.com/adopted-ember-addons/ember-keyboard/blame/bba28a2a33ca4814e291093bc75d4b313323df26/addon/utils/get-code.js#L16-L32) breaks alt-key combos on Macs. 