### PR TITLE
Fix an issue in the keyboard service unit test that left key responders registered

### DIFF
--- a/tests/unit/services/keyboard-test.js
+++ b/tests/unit/services/keyboard-test.js
@@ -1,43 +1,50 @@
-import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Service | keyboard', function(hooks) {
   setupTest(hooks);
 
-  test('`activeResponders` is a filtered list of registeredResponders with keyboardActivated true', function(assert) {
-    const service = this.owner.factoryFor('service:keyboard').create({
-      registeredResponders: A([{
-        keyboardActivated: true
-      }, {
-        keyboardActivated: false
-      }, {
-        keyboardActivated: true
-      }])
-    });
+  let service;
+  hooks.beforeEach(function() {
+    service = this.owner.lookup('service:keyboard');
+  });
 
+  hooks.afterEach(function() {
+    let { registeredResponders } = service;
+    let responder;
+    for (responder of registeredResponders) {
+      service.unregister(responder);
+    }
+  });
+
+  test('`activeResponders` is a filtered list of registeredResponders with keyboardActivated true', function(assert) {
+    service.register({ keyboardActivated: true });
+    service.register({ keyboardActivated: false });
+    service.register({ keyboardActivated: true });
     assert.equal(service.get('activeResponders.length'), 2, 'correct number of responders');
   });
 
   test('`sortedResponders` sorts by keyboardFirstResponder and keyboardPriority', function(assert) {
-    const service = this.owner.factoryFor('service:keyboard').create({
-      registeredResponders: A([{
-        keyboardActivated: true,
-        keyboardPriority: 0
-      }, {
-        keyboardActivated: true,
-        keyboardPriority: -1
-      }, {
-        keyboardActivated: false,
-        keyboardPriority: 50
-      }, {
-        keyboardActivated: true,
-        keyboardPriority: 0,
+    service.register({
+      keyboardActivated: true,
+      keyboardPriority: 0
+    });
+    service.register({
+      keyboardActivated: true,
+      keyboardPriority: -1
+    });
+    service.register({
+      keyboardActivated: false,
+      keyboardPriority: 50
+    });
+    service.register({
+      keyboardActivated: true,
+      keyboardPriority: 0,
         keyboardFirstResponder: true
-      }, {
-        keyboardActivated: true,
-        keyboardPriority: 1
-      }])
+    });
+    service.register({
+      keyboardActivated: true,
+      keyboardPriority: 1
     });
 
     assert.deepEqual(service.get('sortedResponders').mapBy('keyboardPriority'), [0, 1, 0, -1], 'correct sorting');


### PR DESCRIPTION
- Prior to this fix, any click or key press at the end of a test run would throw an error.