### PR TITLE
Deprecate old propagation model

### DIFF
--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { run } from '@ember/runloop';
+import { deprecate } from '@ember/debug';
 import { keyDown, keyPress, keyUp } from 'ember-keyboard/listeners/key-events';
 import {
   handleKeyEventWithPropagation,
@@ -53,6 +54,19 @@ export default class KeyboardService extends Service {
 
     const isPropagationEnabled = Boolean(emberKeyboardConfig.propagation);
     this.isPropagationEnabled = isPropagationEnabled;
+
+    deprecate(
+      'The old event propagation semantics have been deprecated. ' +
+      'You should set `emberKeyboard.propagation = true` in `config/environment.js`.',
+      isPropagationEnabled,
+      {
+        id: 'ember-keyboard.old-propagation-model',
+        for: 'ember-keyboard',
+        since: '6.0.4',
+        until: '7.0.0',
+        url: 'https://adopted-ember-addons.github.io/ember-keyboard/deprecations#old-propagation-model'
+      }
+    );
 
     this._listeners = emberKeyboardConfig.listeners || ['keyUp', 'keyDown', 'keyPress'];
     this._listeners = this._listeners.map((listener) => listener.toLowerCase());

--- a/tests/dummy/app/templates/deprecations.hbs
+++ b/tests/dummy/app/templates/deprecations.hbs
@@ -364,4 +364,21 @@ in the `config/environment.js` to `true`.
 
 Related to this, if you were importing `{ initializer } from 'ember-keyboard'` in any integration tests, this should no
 longer be necessary as Ember integration tests now run initializers themselves. This export will be removed in 7.0 as well.
+
+### <a name='old-propagation-model'></a> Old propagation model
+
+By setting `emberKeyboard.propagation` in the `config/environment.js` to `true`,
+you're opting into the new event propagation semantics that were introduced in
+[issue #63](https://github.com/patience-tema-baron/ember-keyboard/issues/63).
+
+The event propagation is designed to mirror how standard DOM events bubble up
+the parent node chain and supports calling a
+[`stopPropagation()` method](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation)
+and
+[`stopImmediatePropagation()` method](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation)
+on a second event object pased to your handlers.
+
+The old propagation model will be removed in 7.0. To opt out of it now
+and remove the deprecation warning, opt in for the propagation model by setting `emberKeyboard.propagation`
+in the `config/environment.js` to `true`.
 "}}


### PR DESCRIPTION
Closes #164.

Should be released as v6.0.4

Part of #116.