### PR TITLE
Fix marked import in format-markdown helper

### DIFF
--- a/tests/dummy/app/helpers/format-markdown.js
+++ b/tests/dummy/app/helpers/format-markdown.js
@@ -1,4 +1,4 @@
-import marked from 'marked';
+import { marked } from 'marked';
 import hljs from 'highlight.js';
 import { helper } from '@ember/component/helper';
 import { htmlSafe } from '@ember/string';
@@ -20,7 +20,7 @@ export function formatMarkdown([value]) {
 
   let parsedMarkdown = marked.parse(value);
 
-  return new htmlSafe(parsedMarkdown);
+  return htmlSafe(parsedMarkdown);
 }
 
 export default helper(formatMarkdown);


### PR DESCRIPTION
Noticed in `embroider-optimized` scenario output:

```
WARNING in ./helpers/format-markdown.js 14:2-19
export 'default' (imported as 'marked') was not found in 'marked' (possible exports: Lexer, Parser, Renderer, Slugger, TextRenderer, Tokenizer, defaults, getDefaults, lexer, marked, options, parse, parseInline, parser, setOptions, use, walkTokens)
 @ ./templates/deprecations.hbs 1:0-47 3:9-11
 @ ./assets/dummy.js 78:9-49
```

followed recomendation from https://marked.js.org/#usage