### PR TITLE
Move `ember-cli-htmlbars` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^6.0.1",
     "ember-modifier": "^2.1.2 || ^3.0.0",
     "ember-modifier-manager-polyfill": "^1.2.0"
   },
@@ -51,6 +50,7 @@
     "ember-cli-fastboot": "^3.2.0-beta.4",
     "ember-cli-fastboot-testing": "^0.6.0",
     "ember-cli-github-pages": "0.2.2",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",


### PR DESCRIPTION
As this addon does not ship any components/templates there is no need to ship htmlbars as dependency
and only `ember-cli-babel` is needed as it transpiles js files