### PR TITLE
replace highlight.js EOL warning in changelog by title

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,10 +1,4 @@
-Version 9 of Highlight.js has reached EOL and is no longer supported.
-Please upgrade or ask whatever dependency you are using to upgrade.
-https://github.com/highlightjs/highlight.js/issues/2877
-
-
-
-
+# Changelog
 
 ## v8.0.0 (2022-03-17)
 


### PR DESCRIPTION
Highlight.js has already been upgraded to a recent version: https://github.com/adopted-ember-addons/ember-keyboard/blob/e95d348455dc49b6b9812ac12a31fbf775b0b73e/yarn.lock#L7238-L7246 Let's remove the annoying warning as well from changelog.

While doing so I noticed that the changelog does not have a title yet. I added one.