### PR TITLE
Fix ember-modifier v3.2 compatibility

### DIFF
--- a/addon/src/modifiers/on-key.js
+++ b/addon/src/modifiers/on-key.js
@@ -11,95 +11,6 @@ const ONLY_WHEN_FOCUSED_TAG_NAMES = ['input', 'select', 'textarea'];
 let modifier;
 
 if (macroCondition(dependencySatisfies('ember-modifier', '>=3.2.0 || 4.x'))) {
-  modifier = class OnKeyModifier extends Modifier {
-    @service keyboard;
-
-    keyboardPriority = 0;
-    activatedParamValue = true;
-    eventName = 'keydown';
-    onlyWhenFocused = true;
-    listenerName;
-
-    didReceiveArguments() {
-      let [keyCombo, callback] = this.args.positional;
-      let { activated, event, priority } = this.args.named;
-      this.keyCombo = keyCombo;
-      this.callback = callback;
-      this.eventName = event || 'keydown';
-      this.activatedParamValue = Object.keys(this.args.named).includes(
-        'activated'
-      )
-        ? !!activated
-        : undefined;
-      this.keyboardPriority = priority ? parseInt(priority, 10) : 0;
-      this.listenerName = listenerName(this.eventName, this.keyCombo);
-      if (this.args.named.onlyWhenFocused !== undefined) {
-        this.onlyWhenFocused = this.args.named.onlyWhenFocused;
-      } else {
-        this.onlyWhenFocused = ONLY_WHEN_FOCUSED_TAG_NAMES.includes(
-          this.element.tagName.toLowerCase()
-        );
-      }
-    }
-
-    didInstall() {
-      this.keyboard.register(this);
-      if (this.onlyWhenFocused) {
-        this.element.addEventListener('click', this.onFocus, true);
-        this.element.addEventListener('focus', this.onFocus, true);
-        this.element.addEventListener('focusout', this.onFocusOut, true);
-      }
-    }
-
-    willRemove() {
-      if (this.onlyWhenFocused) {
-        this.element.removeEventListener('click', this.onFocus, true);
-        this.element.removeEventListener('focus', this.onFocus, true);
-        this.element.removeEventListener('focusout', this.onFocusOut, true);
-      }
-      this.keyboard.unregister(this);
-    }
-
-    @action onFocus() {
-      this.isFocused = true;
-    }
-
-    @action onFocusOut() {
-      this.isFocused = false;
-    }
-
-    get keyboardActivated() {
-      if (this.activatedParamValue === false) {
-        return false;
-      }
-      if (this.onlyWhenFocused) {
-        return this.isFocused;
-      }
-      return true;
-    }
-
-    get keyboardFirstResponder() {
-      if (this.onlyWhenFocused) {
-        return this.isFocused;
-      }
-      return false;
-    }
-
-    canHandleKeyboardEvent(event) {
-      return isKey(this.listenerName, event);
-    }
-
-    handleKeyboardEvent(event, ekEvent) {
-      if (isKey(this.listenerName, event)) {
-        if (this.callback) {
-          this.callback(event, ekEvent);
-        } else {
-          this.element.click();
-        }
-      }
-    }
-  };
-} else {
   /**
    * This is an element modifier to trigger some behavior when
    * specified key combo is pressed. When used with a form element
@@ -180,6 +91,95 @@ if (macroCondition(dependencySatisfies('ember-modifier', '>=3.2.0 || 4.x'))) {
         this.element.removeEventListener('focusout', this.onFocusOut, true);
       }
     };
+
+    @action onFocus() {
+      this.isFocused = true;
+    }
+
+    @action onFocusOut() {
+      this.isFocused = false;
+    }
+
+    get keyboardActivated() {
+      if (this.activatedParamValue === false) {
+        return false;
+      }
+      if (this.onlyWhenFocused) {
+        return this.isFocused;
+      }
+      return true;
+    }
+
+    get keyboardFirstResponder() {
+      if (this.onlyWhenFocused) {
+        return this.isFocused;
+      }
+      return false;
+    }
+
+    canHandleKeyboardEvent(event) {
+      return isKey(this.listenerName, event);
+    }
+
+    handleKeyboardEvent(event, ekEvent) {
+      if (isKey(this.listenerName, event)) {
+        if (this.callback) {
+          this.callback(event, ekEvent);
+        } else {
+          this.element.click();
+        }
+      }
+    }
+  };
+} else {
+  modifier = class OnKeyModifier extends Modifier {
+    @service keyboard;
+
+    keyboardPriority = 0;
+    activatedParamValue = true;
+    eventName = 'keydown';
+    onlyWhenFocused = true;
+    listenerName;
+
+    didReceiveArguments() {
+      let [keyCombo, callback] = this.args.positional;
+      let { activated, event, priority } = this.args.named;
+      this.keyCombo = keyCombo;
+      this.callback = callback;
+      this.eventName = event || 'keydown';
+      this.activatedParamValue = Object.keys(this.args.named).includes(
+        'activated'
+      )
+        ? !!activated
+        : undefined;
+      this.keyboardPriority = priority ? parseInt(priority, 10) : 0;
+      this.listenerName = listenerName(this.eventName, this.keyCombo);
+      if (this.args.named.onlyWhenFocused !== undefined) {
+        this.onlyWhenFocused = this.args.named.onlyWhenFocused;
+      } else {
+        this.onlyWhenFocused = ONLY_WHEN_FOCUSED_TAG_NAMES.includes(
+          this.element.tagName.toLowerCase()
+        );
+      }
+    }
+
+    didInstall() {
+      this.keyboard.register(this);
+      if (this.onlyWhenFocused) {
+        this.element.addEventListener('click', this.onFocus, true);
+        this.element.addEventListener('focus', this.onFocus, true);
+        this.element.addEventListener('focusout', this.onFocusOut, true);
+      }
+    }
+
+    willRemove() {
+      if (this.onlyWhenFocused) {
+        this.element.removeEventListener('click', this.onFocus, true);
+        this.element.removeEventListener('focus', this.onFocus, true);
+        this.element.removeEventListener('focusout', this.onFocusOut, true);
+      }
+      this.keyboard.unregister(this);
+    }
 
     @action onFocus() {
       this.isFocused = true;

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -5,6 +5,12 @@ const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
+    /**
+     * `ember-classic` scenario should not use `useWorkspaces`
+     * as only test-app need to get classic flags.
+     * Otherwise, this scenario would fail.
+     */
+    useWorkspaces: process.argv.every((a) => !a.includes('ember-classic')),
     useYarn: true,
     scenarios: [
       {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "test-app",
   "version": "8.1.0",
+  "private": true,
   "description": "Test app for ember-keyboard addon",
   "keywords": [],
   "repository": {
@@ -86,5 +87,9 @@
   },
   "volta": {
     "extends": "../package.json"
-  }
+  },
+  "workspaces": [
+    "../addon",
+    "../docs"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5370,9 +5370,9 @@ ember-modifier-manager-polyfill@^1.2.0:
     ember-compatibility-helpers "^1.2.0"
 
 "ember-modifier@^2.1.2 || ^3.1.0":
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.5.tgz#b82052afe941f3b27c0840019992d59466dfbd77"
-  integrity sha512-66YA4pQijoDIAfoI0pYAhjYWu/VrTaD3BfxpA311hLIoBlaI2QQY/LR+32aah1EvKY/yInnCJA5wcl7C+f3mkg==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
+  integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==
   dependencies:
     ember-cli-babel "^7.26.6"
     ember-cli-normalize-entity-name "^1.0.0"


### PR DESCRIPTION
This is fix for the logic/condition introduced in #617

Condition about whether to use new or old version of `on-key` modifier class was flipped.

Additionally, this adds `useWorkspaces` to ember-try config
so that proper version of `ember-modifier` is used
across the monorepo.

This is needed so that `ember-modifier-X` ember-try scenarios
resolve to the same version of `ember-modifier` both in the
`test-app` and `addon` workspaces.

`ember-classic` scenario should not use `useWorkspaces` flag as only test-app need to get classic flags.