### PR TITLE
Fix `isKey` import in documentation usage

### DIFF
--- a/docs/app/templates/usage.hbs
+++ b/docs/app/templates/usage.hbs
@@ -161,7 +161,7 @@ considered to match a specified key-combo will also be exposed.
 It will be available (and used internally) as an `isKey` JS function:
 
 ```js
-import { isKey } from 'ember-keyboard';
+import isKey from 'ember-keyboard/utils/is-key';
 
 function onEvent(ev) {
   if (isKey('keydown:alt+x', ev)) {


### PR DESCRIPTION
I was getting errors using `import { isKey } from 'ember-keyboard';` and the code seems to use `import isKey from 'ember-keyboard/utils/is-key';`.