### PR TITLE
Make keyResponder ember-modifier@4 compat

### DIFF
--- a/addon/src/decorators/key-responder.js
+++ b/addon/src/decorators/key-responder.js
@@ -1,4 +1,5 @@
 import { inject as service } from '@ember/service';
+import { registerDestructor } from '@ember/destroyable';
 
 function populateKeyboardHandlers(responder) {
   responder.keyboardHandlers = responder.keyboardHandlers || {};
@@ -65,11 +66,10 @@ export default function keyResponder(opts = {}) {
         super(...arguments);
         populateKeyboardHandlers(this);
         this.keyboard.register(this);
-      }
 
-      willDestroy() {
-        this.keyboard.unregister(this);
-        super.willDestroy(...arguments);
+        registerDestructor(this, () => {
+          this.keyboard.unregister(this);
+        });
       }
     };
   };


### PR DESCRIPTION
I am getting deprecations thrown from willDestroy from keyResponder used on an ember-modifier class-based modifier.

I think this change fixes things for everyone, and no more deprecations!