### PR TITLE
pin @ember/test-helpers to 2.6.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.6.0",
+    "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "^1.6.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.6.0",
+    "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "^1.6.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,7 +1185,7 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/test-helpers@^2.6.0":
+"@ember/test-helpers@2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.6.0.tgz#d687515c6ab49ba72717fc62046970ef4a72ea9c"
   integrity sha512-N5sr3layWk60wB3maCy+/5hFHQRcTh8aqxcZTSs3Od9QkuHdWBtRgMGLP/35mXpJlgWuu3xqLpt6u3dGHc8gCg==


### PR DESCRIPTION
PR https://github.com/emberjs/ember-test-helpers/pull/1211 (released in v2.8.0)
made `ember-source` a peerDependency of `@ember/test-helpers`.

In case of `ember-keyboard` monorepo setup, package `ember-source`
does not get hoisted and stay in the `test-app/node_modules` but at the same time
`@ember/test-helpers` gets hoisted as well as some another version of `ember-source`.

By pinning `@ember/test-helpers` package we avoid this issue.