### PR TITLE
Allow @ember/test-helpers v3 in peer dependencies

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -55,7 +55,7 @@
     "rollup": "^2.79.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.6.0"
+    "@ember/test-helpers": "^2.6.0 || ^3.0.0"
   },
   "peerDependenciesMeta": {
     "@ember/test-helpers": {


### PR DESCRIPTION
@ember/test-helpers v3 has been released: https://github.com/emberjs/ember-test-helpers/releases/tag/v3.0.0

The `triggerEvent` function used in ember-keyboard is still here, so relaxing the dependencies to allow the v3 is okay.