### PR TITLE
Remove test dependency ember-export-application-global that break most ember 5 tests

### DIFF
--- a/test-app/package.json
+++ b/test-app/package.json
@@ -51,7 +51,6 @@
     "ember-compatibility-helpers": "^1.2.6",
     "ember-decorators-polyfill": "^1.1.5",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-export-application-global": "^2.0.1",
     "ember-fn-helper-polyfill": "^1.0.2",
     "ember-keyboard": "8.2.0",
     "ember-load-initializers": "^2.1.2",


### PR DESCRIPTION
I digged why ember 5 tests were failing. ember-export-application-global was installed but is now deprecated and doesn't seems to be necessary to run tests.
There is one more test failing related to fastboot.