### PR TITLE
Feature: Plus sign support

### DIFF
--- a/addon/src/utils/keyboard-listener.js
+++ b/addon/src/utils/keyboard-listener.js
@@ -25,30 +25,43 @@ export default class KeyboardListener {
     keyCombo = keyCombo.join(':'); // allow keyCombo contain semicolon
     keyboardListener.type = eventType;
 
-    if (keyCombo === '+') {
-      keyboardListener.keyOrCode = keyCombo;
-      return keyboardListener;
-    }
+    let maybePlus = false;
+    keyCombo
+      .split('+')
+      .reduce((result, part) => {
+        if (part === '') {
+          if (maybePlus) {
+            result.push('+');
+          }
 
-    keyCombo.split('+').forEach((part) => {
-      if (ALT_REGEX.test(part)) {
-        keyboardListener.altKey = true;
-      } else if (CTRL_REGEX.test(part)) {
-        keyboardListener.ctrlKey = true;
-      } else if (META_REGEX.test(part)) {
-        keyboardListener.metaKey = true;
-      } else if (SHIFT_REGEX.test(part)) {
-        keyboardListener.shiftKey = true;
-      } else if (CMD_REGEX.test(part)) {
-        if (platform.indexOf('Mac') > -1) {
-          keyboardListener.metaKey = true;
+          maybePlus = !maybePlus;
         } else {
-          keyboardListener.ctrlKey = true;
+          result.push(part);
         }
-      } else {
-        keyboardListener.keyOrCode = part;
+
+        return result;
+      }, [])
+      .forEach((part) => {
+        if (ALT_REGEX.test(part)) {
+          keyboardListener.altKey = true;
+        } else if (CTRL_REGEX.test(part)) {
+          keyboardListener.ctrlKey = true;
+        } else if (META_REGEX.test(part)) {
+          keyboardListener.metaKey = true;
+        } else if (SHIFT_REGEX.test(part)) {
+          keyboardListener.shiftKey = true;
+        } else if (CMD_REGEX.test(part)) {
+          if (platform.indexOf('Mac') > -1) {
+            keyboardListener.metaKey = true;
+          } else {
+            keyboardListener.ctrlKey = true;
+          }
+        } else {
+          keyboardListener.keyOrCode = part;
+        }
       }
-    });
+    );
+
     return keyboardListener;
   }
 

--- a/addon/src/utils/keyboard-listener.js
+++ b/addon/src/utils/keyboard-listener.js
@@ -59,8 +59,7 @@ export default class KeyboardListener {
         } else {
           keyboardListener.keyOrCode = part;
         }
-      }
-    );
+      });
 
     return keyboardListener;
   }

--- a/test-app/app/controllers/test-scenario/on-key-helper-examples.js
+++ b/test-app/app/controllers/test-scenario/on-key-helper-examples.js
@@ -5,4 +5,5 @@ export default class extends Controller {
   wasSPressed = false;
   wasSlashPressed = false;
   wasQuestionMarkPressed = false;
+  wasCtrlPlusPressed = false;
 }

--- a/test-app/app/templates/test-scenario/on-key-helper-examples.hbs
+++ b/test-app/app/templates/test-scenario/on-key-helper-examples.hbs
@@ -30,3 +30,12 @@
 </span>
 
 {{on-key 'shift+Slash' (fn (mut this.wasQuestionMarkPressed) true)}}
+
+<hr />
+
+
+<span data-test-ctrl-plus>
+  {{if this.wasCtrlPlusPressed 'Ctrl++ pressed' 'Ctrl++ not pressed'}}
+</span>
+
+{{on-key 'ctrl++' (fn (mut this.wasCtrlPlusPressed) true)}}

--- a/test-app/tests/acceptance/on-key-helper-test.js
+++ b/test-app/tests/acceptance/on-key-helper-test.js
@@ -84,4 +84,25 @@ module('Acceptance | on-key helper ', function (hooks) {
       }
     );
   });
+
+  test('Ctrl++', async function (assert) {
+    assert.expect(3);
+
+    await textChanged(
+      assert,
+      () =>
+        triggerEvent(document.body, 'keydown', {
+          code: 'Equal',
+          key: '+',
+          keyCode: 43,
+          which: 43,
+          ctrlKey: true,
+        }),
+      {
+        selectorName: 'ctrl-plus',
+        beforeValue: 'Ctrl++ not pressed',
+        afterValue: 'Ctrl++ pressed',
+      }
+    );
+  });
 });


### PR DESCRIPTION
## Why?
Ember-keyboard currently does not support key combos that contain a plus sign and modifier keys, e.g. shift++ and ctrl++.
Also, the colon usage was being achieved through a split/join, but it could be replaced by regex match.

## What it achieves
Adds support for the plus sign in any configuration and uses regex matching to separate the eventType from the keyCombo.

## Upgrade path
No changes are needed, since all previously supported features still work the same way.

## Caveats
The plus sign support could be achieved with a regex split, but it requires lookbehind, which has support conflict with Ember 3.8 and IE.
For that reason, the solution involves splitting by the plus sign and collapsing two subsequent empty strings into a plus sign.
Example: `'Ctrl++'` > `['Ctrl', '', '']` > `['Ctrl', '+']`
Regex with lookbehind: `/(?<=[^+])\+|\+(?=[^+])/g`

## What this PR does
* [x] Use regex for splitting eventType/keyCombo
* [x] Add support for keyCombos with a plus sign