### PR TITLE
Don't evaluate getters when looking for handlers

### DIFF
--- a/test-app/app/components/decorator-example3/component.js
+++ b/test-app/app/components/decorator-example3/component.js
@@ -2,6 +2,7 @@
 /* eslint-disable ember/no-classic-classes */
 /* eslint-disable ember/no-classic-components */
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { keyResponder, onKey } from 'ember-keyboard';
 
 export default keyResponder(
@@ -26,5 +27,10 @@ export default keyResponder(
         }
       })
     ),
+
+    // This exists to ensure that we don't call getters when looking for handlers
+    doNotCall: computed(function () {
+      throw new Error('This should not be called');
+    }),
   })
 );


### PR DESCRIPTION
When working with classic properties, ember-keyboard crawls all properties to look for handlers. However, this would evaluate computed properties which is something we should avoid.