### PR TITLE
Fix ember deprecation of inject as service

### DIFF
--- a/addon/src/decorators/key-responder.js
+++ b/addon/src/decorators/key-responder.js
@@ -1,5 +1,7 @@
-import { service } from '@ember/service';
+import * as emberService from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
+
+const service = emberService.service ?? emberService.inject;
 
 function findPropertyDescriptor(obj, name) {
   let descriptor;

--- a/addon/src/decorators/key-responder.js
+++ b/addon/src/decorators/key-responder.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
 
 function findPropertyDescriptor(obj, name) {

--- a/addon/src/helpers/on-key.js
+++ b/addon/src/helpers/on-key.js
@@ -1,7 +1,9 @@
 import Helper from '@ember/component/helper';
 import { assert } from '@ember/debug';
-import { service } from '@ember/service';
+import * as emberService from '@ember/service';
 import listenerName from '../utils/listener-name';
+
+const service = emberService.service ?? emberService.inject;
 
 export default class extends Helper {
   @service keyboard;

--- a/addon/src/helpers/on-key.js
+++ b/addon/src/helpers/on-key.js
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 import { assert } from '@ember/debug';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import listenerName from '../utils/listener-name';
 
 export default class extends Helper {

--- a/addon/src/modifiers/on-key.js
+++ b/addon/src/modifiers/on-key.js
@@ -1,5 +1,5 @@
 import Modifier from 'ember-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { registerDestructor } from '@ember/destroyable';
 import { macroCondition, dependencySatisfies } from '@embroider/macros';

--- a/addon/src/modifiers/on-key.js
+++ b/addon/src/modifiers/on-key.js
@@ -1,11 +1,12 @@
 import Modifier from 'ember-modifier';
-import { service } from '@ember/service';
+import * as emberService from '@ember/service';
 import { action } from '@ember/object';
 import { registerDestructor } from '@ember/destroyable';
 import { macroCondition, dependencySatisfies } from '@embroider/macros';
 import listenerName from '../utils/listener-name';
 import isKey from '../utils/is-key';
 
+const service = emberService.service ?? emberService.inject;
 const ONLY_WHEN_FOCUSED_TAG_NAMES = ['input', 'select', 'textarea'];
 
 let modifier;

--- a/docs/app/components/keyboard-propagation-widget.js
+++ b/docs/app/components/keyboard-propagation-widget.js
@@ -3,9 +3,11 @@
 /* eslint-disable ember/no-classic-components */
 /* eslint-disable ember/no-mixins */
 import Component from '@ember/component';
-import { service } from '@ember/service';
+import * as emberService from '@ember/service';
 import { set } from '@ember/object';
 import EnterableMixin from 'docs/mixins/enterable';
+
+const service = emberService.service ?? emberService.inject;
 
 export default Component.extend(EnterableMixin, {
   keyboard: service(),

--- a/docs/app/components/keyboard-propagation-widget.js
+++ b/docs/app/components/keyboard-propagation-widget.js
@@ -3,7 +3,7 @@
 /* eslint-disable ember/no-classic-components */
 /* eslint-disable ember/no-mixins */
 import Component from '@ember/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { set } from '@ember/object';
 import EnterableMixin from 'docs/mixins/enterable';
 

--- a/docs/app/mixins/enterable.js
+++ b/docs/app/mixins/enterable.js
@@ -1,5 +1,5 @@
 /* eslint-disable ember/no-new-mixins */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({

--- a/docs/app/mixins/enterable.js
+++ b/docs/app/mixins/enterable.js
@@ -1,6 +1,8 @@
 /* eslint-disable ember/no-new-mixins */
-import { service } from '@ember/service';
+import * as emberService from '@ember/service';
 import Mixin from '@ember/object/mixin';
+
+const service = emberService.service ?? emberService.inject;
 
 export default Mixin.create({
   classNames: ['keyboard-widget'],


### PR DESCRIPTION
I recently upgraded to ember 6.3. With the new deprecation on importing as `{ inject as service }`. See: 
 https://deprecations.emberjs.com/id/importing-inject-from-ember-service
I replaced the import statements by the new correct imports.