### PR TITLE
Remove ember-destroyable-polyfill from dependencies

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.4",
-    "ember-destroyable-polyfill": "^2.0.3",
     "ember-modifier": "^2.1.2 || ^3.1.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@embroider/addon-shim':
         specifier: ^1.8.4
         version: 1.8.7
-      ember-destroyable-polyfill:
-        specifier: ^2.0.3
-        version: 2.0.3(@babel/core@7.24.0)
       ember-modifier:
         specifier: ^2.1.2 || ^3.1.0 || ^4.0.0
         version: 4.1.0(ember-source@4.3.0(@babel/core@7.24.0))


### PR DESCRIPTION
Removed ember-destroyable-polyfill dependency. 
(it's not used for currently supported ember matrix)